### PR TITLE
fix: read PAT from stdin rather than file

### DIFF
--- a/addCodeowners.sh
+++ b/addCodeowners.sh
@@ -50,8 +50,7 @@ cd "./addCodeowners"
 
 echo "Authenticating w/ PAT"
 
-echo $PAT > ./pat.txt
-gh auth login --with-token < pat.txt
+echo $PAT | gh auth login --with-token
 
 echo "Cloning Team Repos"
 


### PR DESCRIPTION
This modifies the script so the PAT does not need to be written to a file. Less cleanup work for the developer, and better security! (i.e. no plain text PATs laying around)

Tested successfully on Linux